### PR TITLE
fix typo in parse.py L170

### DIFF
--- a/src/slurm_monitor/parse.py
+++ b/src/slurm_monitor/parse.py
@@ -167,7 +167,7 @@ def print_node(row, draw: bool = True, filter_irrelevant: bool = True) -> Option
         return gpu_str
 
     outs = []
-    gpu_str = f'{row['node']:5s}'
+    gpu_str = f"{row['node']:5s}"
     outs.append(gpu_str)
     if gpu_available > 0:
         gpu_str = click.style(f'{gpu_available}', fg='green')


### PR DESCRIPTION
python version 3.10.12
src/slurm_monitor/parse.py L170:
gpu_str = f'{row['node']:5s}' 
is edited into 
gpu_str = f"{row['node']:5s}"